### PR TITLE
Dialogue Preservation

### DIFF
--- a/Gopher/Gopher.lua
+++ b/Gopher/Gopher.lua
@@ -1,4 +1,4 @@
-    -------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 -- Gopher
 -- by Tammya-MoonGuard (Copyright 2018)
 --
@@ -1042,7 +1042,7 @@ function Me.HandleVeryLongQuotes(link)
       if(i+1 <= table_length) then
          -- begin doing splitting! we keep track of the next word in the message,
          -- as well as a little bool that tells us if we've hit punctuation.
-
+         -- (maybe remove the comma as a breakpoint? could look nicer!)
          next_word = words[i+1]
          sentence_end = (string.find(string.sub(word, -1), "[%.,!%?%-]")) == 1
 


### PR DESCRIPTION
Simple changes! This branch has only a few additional features.
1. I've added a replacement pattern for quote blocks, which means dialogue shouldn't ever be broken.
2. I've added logic to break huge links (really, only quotes) across multiple messages.
3. Quality of life features that let the user know if they're missing a quotation mark that would ruin their formatting, or if they've got the AFK tag on, before sending their emote.

The goal with these changes is to let writers focus on writing, rather than making sure their quotes land within chunks. The addon, now, will handle preserving the legibility of dialogue, doing its best not to step on the author's toes.

Example message without changes:
<img width="553" alt="emotesplitterregular" src="https://user-images.githubusercontent.com/96760339/147713857-61debc79-4bd3-4332-8a31-edf7673ce8f8.png">

Example message with changes:
<img width="563" alt="emotesplitterquotable" src="https://user-images.githubusercontent.com/96760339/147713870-d930ba02-e3f6-4ba6-8b28-1c85a78db700.png">

I'd appreciate if you could take a look at these changes, and consider adding them to the main branch– in some form or another. :)