### PR TITLE
Gopher:  EmoteSplitter:  Support WoW 12.0.

### DIFF
--- a/Gopher/Gopher.lua
+++ b/Gopher/Gopher.lua
@@ -1923,8 +1923,56 @@ function Me.PromptForContinue()
 end
 
 -------------------------------------------------------------------------------
+function Me.OnEditBoxPreSendText( ... )
+   local _, edit_box = ...
+   local text = edit_box:GetText()
+   local type = edit_box:GetChatType()
+   if #text > 255 then
+
+      --
+      -- Clear the edit box text so that the edit box does not attempt to send
+      -- the message directly.
+      --
+      edit_box:SetText("")
+      if C_ChatInfo.InChatMessagingLockdown() then
+         DEFAULT_CHAT_FRAME:AddMessage("EmoteSplitter: Messages longer than 255 characters can't be sent while instanced content chat AddOn restrictions are active, due to Blizzard AddOn restrictions.  Shorten the message, and try again.", 1, 0, 0)
+         return
+      end
+
+      --
+      -- Handle the message as ChatFrameEditBoxBaseMixin:SendText() would,
+      -- except sending the message through Gopher's splitter routines.
+      --
+
+      if type == "WHISPER" then
+         local target = edit_box:GetTellTarget()
+         ChatFrameUtil.SetLastToldTarget( target, type )
+         Me.SendChatMessageHook( text, type, edit_box.languageID, target )
+      elseif type == "BN_WHISPER" then
+         local target = edit_box:GetTellTarget()
+         local bnetIDAccount = BNet_GetBNetIDAccount( target )
+         if bnetIDAccount then
+            ChatFrameUtil.SetLastToldTarget( target, type )
+            Me.BNSendWhisperHook( bnetIDAccount, text )
+         else
+            ChatFrameUtil.DisplaySystemMessageInPrimary( format( BN_UNABLE_TO_RESOLVE_NAME,
+                                                                 target ))
+         end
+      elseif type == "CHANNEL" then
+         Me.SendChatMessageHook( text, type, edit_box.languageID, edit_box:GetChannelTarget() )
+      else
+         Me.SendChatMessageHook( text, type, edit_box.languageID )
+      end
+   end
+end
+
+-------------------------------------------------------------------------------
 -- Hooks
 -------------------------------------------------------------------------------
+-- WoW 12.0:  It's no longer possible to hook send chat APIs without breaking
+--  chat in instances.  Instead, ChatFrame.OnEditBoxPreSendText is used to
+--  split chat messages when addon chat restrictions are not in force.
+--
 -- VERSION 7: We hook the chat functions as soon as possible. This is riskier
 --  for future compatibility and may introduce some quirks, but this allows us
 --  finer control over the chat system, and better compatibility with other
@@ -1940,16 +1988,16 @@ if not Me.hooks.SendChatMessage then
    --  later. In other words we don't want a static reference to
    --  SendChatMessageHook, because that function might change when we 
    --  load a newer version.
-   function C_ChatInfo.SendChatMessage( ... )
-      return Me.SendChatMessageHook( ... )
-   end
+--   function C_ChatInfo.SendChatMessage( ... )
+--      return Me.SendChatMessageHook( ... )
+--   end
 end
 
 if not Me.hooks.BNSendWhisper then
-   Me.hooks.BNSendWhisper = BNSendWhisper
-   function BNSendWhisper( ... )
-      return Me.BNSendWhisperHook( ... )
-   end
+--   Me.hooks.BNSendWhisper = BNSendWhisper
+--   function BNSendWhisper( ... )
+--      return Me.BNSendWhisperHook( ... )
+--   end
 end
 
 if not Me.hooks.ChatFrame_OpenChat then
@@ -1962,11 +2010,19 @@ end
 if C_Club then -- [7.x compat]
    if not Me.hooks.ClubSendMessage then
       Me.hooks.ClubSendMessage = C_Club.SendMessage
-      C_Club.SendMessage = function( ... )
-         return Me.ClubSendMessageHook( ... )
-      end
+--      C_Club.SendMessage = function( ... )
+--         return Me.ClubSendMessageHook( ... )
+--      end
    end
 end
+
+--
+-- Register for chat pre-send events to engage emote splitting if possible.
+--
+
+EventRegistry:RegisterCallback("ChatFrame.OnEditBoxPreSendText", function( ... )
+   Me.OnEditBoxPreSendText( ... )
+   end)
 
 -------------------------------------------------------------------------------
 -- Timer API

--- a/src/EmoteSplitter.lua
+++ b/src/EmoteSplitter.lua
@@ -177,7 +177,10 @@ function Me:OnEnable()
 	end
 	
 	-- Our community chat hack entry.
-	Me.UnlockCommunitiesChat()
+	-- Disabled for 12.0 as there's no pre-send event that the game developers
+	-- have provided for the communities chat frame, to avoid taint propagation
+	-- breaking instance chat.
+	-- Me.UnlockCommunitiesChat()
 	
 	-- A nice little sending indicator that appears at the bottom left corner.
 	--  This indicator shows when the system is busy sending, or waiting a bit

--- a/src/EmoteSplitter.toc
+++ b/src/EmoteSplitter.toc
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-## Interface: 110207
+## Interface: 120000
 ## Title: Emote Splitter
 ## Version: @@addon_version@@
 ## Notes: Unlocks chatbox and splits long emotes.


### PR DESCRIPTION
This PR adds basic support for Midnight.  It's been in local use for about 6 weeks without apparent issues in 12.0.0 and 12.0.1.

This change is carefully tailored to avoid permanently breaking instance chat.


Note:  It would still seem advisable to check for and update dependency libraries.  This PR doesn't do so, except for reworking Gopher to work with 12.0.

The same changes could be taken for Cross RP "as-is" with regard to Gopher itself, but Cross RP requires additional reworking, mainly issecretvalue tests inside Cross RP itself to avoid breaking when chat restrictions are enforced, and awareness of upstream changes to Elephant to avoid Lua errors at startup.

Source commit description follows :


Use the chat input edit box's pre-send-message callback registry event to modify the chat message to be sent through the Gopher machinery, as opposed to hooking the internal send chat APIs (as such would permanently break instance chat when chat restrictions are enforced).

Long chat messages give an error asking the user to limit the length when chat restrictions are active.  When chat restrictions are inactive, long chat message are split as before.

Integration with the club/guild UI is disabled with this change, as there appeared to be no such pre-send-message event, and the UI would likely need to be entirely rebuilt locally (and swapped with the stock Blizzard one being shown before chat restrictions are activated).  As a workaround, if chat channel linkages for communities were established by the user, /channel-number via the main text UI can be used to send long community messages, instead.

Instance chat restrictions can be simulated via the following:

/run SetCVar("addonChatRestrictionsForced",1)

... which can be returned to the default state via this:

/run SetCVar("addonChatRestrictionsForced",0)

The simulation mode is not persisted outside of a game session, if it is left enabled.